### PR TITLE
java에서 제공하는 synchronized를 사용한 방법과 문제점

### DIFF
--- a/src/main/java/com/example/stock/service/StockService.java
+++ b/src/main/java/com/example/stock/service/StockService.java
@@ -15,7 +15,10 @@ public class StockService {
     }
 
     @Transactional
-    public void decrease(Long id, Long quantity) {
+    public synchronized void decrease(Long id, Long quantity) {
+        // tranaction을 사용하면 영속성 context에 데이터를 넣어두고 DB에 쓰기 까지 Gap이 생기면서 원하는 결과 처리가 안된다.
+        // java에서 제공하는 synchronized는 각 프로세스 안에서만 보장이 가능함
+        // 그러나 여러 서버에서 동시에 접근하게 되면 race condition은 여전히 발생하게 됨
         Stock stock = stockRepository.findById(id).orElseThrow();
 
         stock.decrease(quantity);


### PR DESCRIPTION
- tranaction을 사용하면 영속성 context에 데이터를 넣어두고 DB에 쓰기 까지 Gap이 생기면서 원하는 결과 처리가 안된다.
- java에서 제공하는 synchronized는 각 프로세스 안에서만 보장이 가능함
- 그러나 여러 서버에서 동시에 접근하게 되면 race condition은 여전히 발생하게 됨